### PR TITLE
files.upload API 廃止対応

### DIFF
--- a/app.gs
+++ b/app.gs
@@ -7,12 +7,15 @@ function checkBuyMail() {
     thread.getMessages().forEach((message) => {
       if(!message.isUnread()) { return }
       const text = create_message(message);
-      const webhookUrls = [
-        "https://hooks.slack.com/services/xxx/xxx", // ココに通知先のSlackのWebhook URLを入れる。複数の通知先に送りたい場合はカンマ区切りで指定する。
+      const webhookUrls = [ // ココに通知先のSlackのWebhook URLを入れる。複数の通知先に送りたい場合はカンマ区切りで指定する。
+        "https://hooks.slack.com/services/xxx",
+        "https://hooks.slack.com/services/yyy",
       ]
       webhookUrls.forEach((webhookUrl) => {
         sendTextToSlack(text, webhookUrl);
-        calcBuyData(message, webhookUrl);
+        if (webhookUrl === "https://hooks.slack.com/services/xxx") { // 画像を投稿する場合
+          calcBuyData(message);
+        }
       });
       message.markRead();
     })
@@ -61,14 +64,14 @@ function extBookTitle(message, titles) {
 
 function getTargetSheet(sheetName){
   // 集計結果を書き込むスプレッドシートを取得
-  var spread = SpreadsheetApp.openById("XXX"); // XXXには書き出すスプレッドシートのIDを記載する
+  var spread = SpreadsheetApp.openById("xxx"); // ココにスプレッドシートのIDを記載する
   var sheet = spread.getSheetByName(sheetName);
   return sheet;
 }
 
 function getStartDate(sheetName) {
   // 集計の開始日を取得する
-  // 基本的には技術書典の開催日
+  // 基本的には技術書展の開催日
   var sheet = getTargetSheet(sheetName);
 
   var startDate = sheet.getRange("A2").getValue();
@@ -126,7 +129,7 @@ function incrementCellValue(sheetName, row, columName, columnMap) {
   cell.setValue(incrementValue);
 }
 
-function createLineChartWithMultipleSeries(sheetName, webhookUrl, maxRow) {
+function createLineChartWithMultipleSeries(sheetName, maxRow) {
   // 集計結果をグラフにする
   const sheet = getTargetSheet(sheetName);
 
@@ -136,53 +139,112 @@ function createLineChartWithMultipleSeries(sheetName, webhookUrl, maxRow) {
     sheet.removeChart(c);
   })
 
-  const dataRange = sheet.getRange(1,1,maxRow,5);
+  // グラフを描画する範囲
+  const dataRange = sheet.getRange(1,1,maxRow,7);
 
   const chart = sheet.newChart()
   .asBarChart()
   .addRange(dataRange)
   .setChartType(Charts.ChartType.BAR)
-  .setPosition(2, 7, 0, 0)
+  .setPosition(2, 10, 0, 0)
   .setOption("useFirstColumnAsDomain", "true")
   .setNumHeaders(1)
   .setOption("legend", {position: "bottom"})
   .build();
 
   sheet.insertChart(chart)
-  sendChartToSlack(chart, webhookUrl);
+  sendChartToSlack(chart);
 }
 
-function sendChartToSlack(chart, webhookUrl) {
-  var chartImage = chart.getBlob().getAs("image/png").setName("book_chart.png");
-  var webhookUrl = "https://slack.com/api/files.upload";
-  var token = "xoxb-xxx-xxx-xxx"; // ココにBot User OAuth Tokenを記載する
-  var channel = "C041Y195CLC"; // ココに通知先のチャンネルIDを記載する
+function sendChartToSlack(chart) {
+  var fileName = "book_chart.png";
+  var chartImage = chart.getBlob().getAs("image/png").setName(fileName);
+  var fileSize = chartImage.getBytes().length;
 
+  var token = "xoxb-xxx"; // ココにBot User OAuth Tokenを記載する
+  var channel = "xxx"; // ココに通知先のチャンネルIDを記載する
+
+  // Step 1: Get Upload URL and File ID
+  var uploadInfo = getSlackUploadURL(token, fileSize, fileName);
+  var uploadUrl = uploadInfo.upload_url;
+  var fileId = uploadInfo.file_id;
+
+  // Step 2: Upload file to Slack
+  uploadFileToSlack(uploadUrl, chartImage);
+
+  // Step 3: Complete the file upload and post it to the channel
+  completeSlackFileUpload(token, fileId, channel);
+}
+
+function getSlackUploadURL(token, fileSize, fileName) {
+  var url = "https://slack.com/api/files.getUploadURLExternal";
   var payload = {
     'token': token,
-    'channels': channel,
-    'file': chartImage,
-    'filename': '売り上げチャート'
+    'length': fileSize.toString(),
+    'filename': fileName
   };
 
   var options = {
     'method': 'post',
     'payload': payload
-  }
-  var response = UrlFetchApp.fetch(webhookUrl, options).getContentText('UTF-8');
+  };
 
+  var response = UrlFetchApp.fetch(url, options);
+  var json = JSON.parse(response.getContentText());
+  if (json.ok) {
+    return {
+      'upload_url': json.upload_url,
+      'file_id': json.file_id
+    };
+  } else {
+    throw new Error("Failed to get upload URL: " + json.error);
+  }
 }
 
-function calcBuyData(message, webhookUrl) {
+function uploadFileToSlack(uploadUrl, fileBlob) {
+  var options = {
+    'method': 'post',
+    'payload': fileBlob
+  };
+
+  var response = UrlFetchApp.fetch(uploadUrl, options);
+  if (response.getResponseCode() !== 200) {
+    throw new Error("Failed to upload file: " + response.getContentText());
+  }
+}
+
+function completeSlackFileUpload(token, fileId, channel) {
+  var url = "https://slack.com/api/files.completeUploadExternal";
+  var payload = {
+    'files': [{'id': fileId, 'title': '売り上げチャート'}],
+    'channel_id': channel
+  };
+
+  var options = {
+    'method': 'post',
+    'headers': {
+      'Authorization': 'Bearer ' + token,
+      'Content-Type': 'application/json'
+    },
+    'payload': JSON.stringify(payload)
+  };
+
+  var response = UrlFetchApp.fetch(url, options);
+  var json = JSON.parse(response.getContentText());
+  if (!json.ok) {
+    throw new Error("Failed to complete file upload: " + json.error);
+  }
+}
+
+function calcBuyData(message) {
   // シート名を指定する
-  const event = "techbookfest15"; // ココに該当のスプレッドシートの該当シート名を記載する
+  const event = "xxx"; // ココに該当のスプレッドシートの該当シート名を記載する
   // 書籍のタイトル一覧を記載する
   // key がタイトルで value がスプレッドシートの列番号
   const columnMap = {
     "BookA": 2,
     "BookB": 3,
     "BookC": 4,
-    "BookD": 5,
   }
   const titles = Object.keys(columnMap);
   const bookTitle = extBookTitle(message, titles);
@@ -190,5 +252,5 @@ function calcBuyData(message, webhookUrl) {
   var diffDays = calcDiffDates(startDate);
   writeDatesFromStartDate(event);
   incrementCellValue(event, diffDays+1, bookTitle, columnMap);
-  createLineChartWithMultipleSeries(event, webhookUrl, diffDays+1);
+  createLineChartWithMultipleSeries(event, diffDays+1);
 }

--- a/app.gs
+++ b/app.gs
@@ -64,14 +64,14 @@ function extBookTitle(message, titles) {
 
 function getTargetSheet(sheetName){
   // 集計結果を書き込むスプレッドシートを取得
-  var spread = SpreadsheetApp.openById("xxx"); // ココにスプレッドシートのIDを記載する
+  var spread = SpreadsheetApp.openById("XXX"); // ココにスプレッドシートのIDを記載する
   var sheet = spread.getSheetByName(sheetName);
   return sheet;
 }
 
 function getStartDate(sheetName) {
   // 集計の開始日を取得する
-  // 基本的には技術書展の開催日
+  // 基本的には技術書典の開催日
   var sheet = getTargetSheet(sheetName);
 
   var startDate = sheet.getRange("A2").getValue();
@@ -140,13 +140,13 @@ function createLineChartWithMultipleSeries(sheetName, maxRow) {
   })
 
   // グラフを描画する範囲
-  const dataRange = sheet.getRange(1,1,maxRow,7);
+  const dataRange = sheet.getRange(1,1,maxRow,5);
 
   const chart = sheet.newChart()
   .asBarChart()
   .addRange(dataRange)
   .setChartType(Charts.ChartType.BAR)
-  .setPosition(2, 10, 0, 0)
+  .setPosition(2, 7, 0, 0)
   .setOption("useFirstColumnAsDomain", "true")
   .setNumHeaders(1)
   .setOption("legend", {position: "bottom"})
@@ -245,6 +245,7 @@ function calcBuyData(message) {
     "BookA": 2,
     "BookB": 3,
     "BookC": 4,
+    "BookD": 5,
   }
   const titles = Object.keys(columnMap);
   const bookTitle = extBookTitle(message, titles);


### PR DESCRIPTION
### Overview

2025年3月にSlackのfiles.upload APIが廃止されるアナウンスがあった。
https://zenn.dev/slack/articles/7ce5065cc4daa7

これを受けて、新方式への移行を行う。

### Changes

- files.upload APIを新方式に移行
  1. [files.getUploadURLExternal API](https://api.slack.com/methods/files.getUploadURLExternal) を呼び出してファイルアップロードに使用する `https://files.slack.com/upload/v1/...` URL とファイル ID を取得する
  2. `https://files.slack.com/upload/v1/...` URL に POST リクエストを送信してファイルをアップロードする
  3. [files.completeUploadExternal API](https://api.slack.com/methods/files.completeUploadExternal) にファイル ID に加えて チャンネル ID などを送信して、アップロード処理を完了させる
- コメントを追加
- 無駄な処理を削除

### CheckList

- [x] 従来通りSlackへの画像の送信ができること